### PR TITLE
Fix incorrect port reference in index file.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
 import app from './src/app'
-const port = process.env.port || 8080
+const port = process.env.PORT || 8080
 app.listen(port, () => console.log(`App listening on port ${port}!`))


### PR DESCRIPTION
The env variable was being incorrectly referenced in the index file as `port`