### PR TITLE
Update book search and transformer tests to work with view templates.

### DIFF
--- a/src/controllers/__tests__/searchController.test.ts
+++ b/src/controllers/__tests__/searchController.test.ts
@@ -14,6 +14,6 @@ describe('GET /', () => {
 
   test('on unsuccessful search, no results are within response', async () => {
     const response = await request(app).get("/?search=ZZXGHJK54345")
-    expect(response.text).toMatch("[]")
+    expect(response.text).not.toMatch(/.*Dracula.*/)
   })
 })

--- a/src/lib/__tests__/bookDataTransformerService.test.ts
+++ b/src/lib/__tests__/bookDataTransformerService.test.ts
@@ -60,7 +60,7 @@ describe('BookTransformer with successful search', () => {
     delete rawData.items[0].volumeInfo.imageLinks
 
     const bookData = BookDataTransformer.parse(rawData)
-    const missingImageUrl = "src/public/images/defaultThumbnail.png"
+    const missingImageUrl = "images/defaultThumbnail.png"
     const testData = [
       new BookInfo({
         title: 'Dracula',


### PR DESCRIPTION
This PR makes some minor changes to exists tests. There was a small regression in them after add view templates.